### PR TITLE
Feat/disable canvas on results

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -121,6 +121,8 @@ describe("Core Game Tests", () => {
     expect(resultSection).not.toBeInTheDocument();
     expect(nextPromptButton).not.toBeInTheDocument();
   });
+
+  // TODO: Maybe write a test to check if button disability works?
 });
 
 describe("Results Screen Tests", () => {

--- a/src/components/Sketchpad.tsx
+++ b/src/components/Sketchpad.tsx
@@ -17,13 +17,25 @@ function Sketchpad(_: unknown, ref: Ref<SketchpadRef>) {
   const isCanvasDisabled = turnCycleState !== TurnCycleState.Drawing;
 
   // For functions that other components / parent need
-  useImperativeHandle(ref, () => ({
-    clearCanvas: () => {
-      clearCanvas();
-    },
-  }));
+  useImperativeHandle(
+    ref,
+    () => ({
+      clearCanvas: () => {
+        clearCanvas();
+      },
+    }),
+    []
+  );
 
+  // This clear canvas is passed upward to the game.tsx, it needs to be called when turn cycle is at results so that is why no !isCanvasDisabled
   const clearCanvas = () => {
+    if (canvasRef.current) {
+      canvasRef.current.clearCanvas();
+    }
+  };
+
+  // This clear canvas is used for the red trash button
+  const onTrashClick = () => {
     if (canvasRef.current && !isCanvasDisabled) {
       canvasRef.current.clearCanvas();
     }
@@ -106,7 +118,7 @@ function Sketchpad(_: unknown, ref: Ref<SketchpadRef>) {
         </button>
         <button
           aria-label="clear canvas"
-          onClick={clearCanvas}
+          onClick={onTrashClick}
           disabled={isCanvasDisabled}
           className="bg-red-400 py-3 px-3 text-2xl text-white rounded-xl shadow-lg hover:cursor-pointer transition hover:scale-110
           disabled:bg-red-300 disabled:opacity-80 disabled:hover:scale-100 disabled:hover:cursor-default"


### PR DESCRIPTION
## Summary
This PR disables the submit button and the trash button on the loading stage and results stage of the round. 

## Changes 
- Disabled the handle summit function on loading and results
- Disabled the submit drawing and trash button on loading and results 
- Got rid of unnecessary import in tests 
- Buttons become more transparent on disabled state

## Preview

<img width="1708" height="953" alt="image" src="https://github.com/user-attachments/assets/06193266-86ac-417c-8682-a38627d42648" />

## Reflection 

This was a well needed PR and feature addition. Felt like this was one of the main things holding me back from deploying the API key fully to production. Very simple and painless with the `const isCanvasDisabled = turnCycleState !== TurnCycleState.Drawing;` that was very intuitive. 

## Closes #33 
