### PR TITLE
fix: api route address

### DIFF
--- a/src/components/Sketchpad.tsx
+++ b/src/components/Sketchpad.tsx
@@ -63,7 +63,7 @@ function Sketchpad(_: unknown, ref: Ref<SketchpadRef>) {
     try {
       // API Call
 
-      const response = await fetch("http://localhost:3000/api/generate-response", {
+      const response = await fetch("/api/generate-response", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ image: rawBase64Data }),


### PR DESCRIPTION
## Summary 

This PR changes the called API address from http://localhost:3000/api/generate-response to /api/generate-response, preparing it for production

## Reflection

I was surprised by how simple this change was. So apparently next when calling apis dynamically builds the route from your domain. Thats really smart!

## Closes #61 