### PR TITLE
fix: switch keep alive ping to a upsert

### DIFF
--- a/.github/workflows/supabase-keep-alive-ping.yml
+++ b/.github/workflows/supabase-keep-alive-ping.yml
@@ -1,8 +1,7 @@
 name: Supabase Keep-Alive Ping
 on:
   schedule:
-    # Runs at 00:00 UTC every Sunday, Wednesday, and Friday
-    - cron: "0 0 * * 0,3,5"
+    - cron: "0 0 * * *" # daily, drop the 3x/week one
   workflow_dispatch:
 
 jobs:
@@ -14,6 +13,11 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
         run: |
-          curl -f -X GET "$NEXT_PUBLIC_SUPABASE_URL/rest/v1/supabase_ping?select=id&limit=1" \
-          -H "apikey: $NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY" \
-          -H "Authorization: Bearer $NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY"
+          set -euo pipefail
+          curl --fail-with-body --show-error --silent \
+            -X POST "$NEXT_PUBLIC_SUPABASE_URL/rest/v1/supabase_ping?on_conflict=id" \
+            -H "apikey: $NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY" \
+            -H "Authorization: Bearer $NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY" \
+            -H "Content-Type: application/json" \
+            -H "Prefer: resolution=merge-duplicates,return=representation" \
+            --data "{\"id\":1,\"last_ping\":\"$(date -u +%FT%TZ)\"}"


### PR DESCRIPTION
## Summary

The Supabase keep-alive workflow was running green but not actually keeping the DB awake, the `GET` ping was being silently blocked by RLS, returning `[]` with a 200. DB kept pausing every ~7 days.

## Changes

- Switched ping from `GET` to upsert - writes are unambiguous DB activity
- Better curl flags (`--fail-with-body --show-error`) + `set -euo pipefail` so failures are loud and specific
- Cron now daily instead of 3x/week 

Schema (applied in Supabase dashboard): disabled RLS on `supabase_ping`, added `last_ping timestamptz`.

## Notes

Verified via manual dispatch - log shows `[{"id":1,"last_ping":"2026-05-16T03:04:37+00:00"}]` and row is visible in dashboard. Should monitor scheduled runs for a few days before fully trusting it.


## Reflection

 So I learned a little bit more about databases today and cron jobs, as well as the whole flakiness, as well as a little bit about curl. Stepping into backend, getting more familiar as I probably will prepare to implement user auth 
 
 ## Issues
- Closes #97 