### PR TITLE
Feat/privacy and terms page

### DIFF
--- a/src/app/privacy/__tests__/page.test.tsx
+++ b/src/app/privacy/__tests__/page.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import PrivacyPage from "../page";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Privacy Policy Page", () => {
+  it("renders the title and last updated date", () => {
+    render(<PrivacyPage />);
+
+    expect(screen.getByRole("heading", { level: 1, name: "Privacy Policy" })).toBeInTheDocument();
+    expect(screen.getByText(/Last updated:/)).toBeInTheDocument();
+  });
+
+  it("renders the key tailored sections", () => {
+    render(<PrivacyPage />);
+
+    expect(screen.getByRole("heading", { name: "Information we collect" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Services we share data with" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Data retention" })).toBeInTheDocument();
+  });
+
+  it("names the third-party services we share data with", () => {
+    render(<PrivacyPage />);
+
+    expect(screen.getByText("OpenRouter")).toBeInTheDocument();
+    expect(screen.getByText("Google (Gemini)")).toBeInTheDocument();
+    expect(screen.getByText("Supabase")).toBeInTheDocument();
+    expect(screen.getByText("Vercel")).toBeInTheDocument();
+  });
+
+  it("provides a back-to-game link pointing at the home route", () => {
+    render(<PrivacyPage />);
+
+    const backLink = screen.getByRole("link", { name: /Back to game/ });
+    expect(backLink).toHaveAttribute("href", "/");
+  });
+});

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,152 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | What the Sketch?",
+  description: "How What the Sketch? handles your drawings and data.",
+};
+
+const CONTACT_EMAIL = "ericzhangdeveloper@gmail.com";
+
+function ExternalLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" className="underline hover:text-black">
+      {children}
+    </a>
+  );
+}
+
+export default function PrivacyPage() {
+  return (
+    <main className="container mx-auto max-w-3xl flex flex-col gap-4 pt-12 pb-24 px-4 text-lg sm:text-xl text-slate-800">
+      <h1 className="text-5xl sm:text-6xl text-center text-black">Privacy Policy</h1>
+      <p className="text-base text-slate-600 text-center mb-4">Last updated: June 6, 2026</p>
+
+      <div className="flex flex-col gap-4 bg-white px-4 md:px-8 py-6 border-2 border-black shadow-[6px_8px_0px_0px_rgba(0,0,0,1)] rounded-3xl">
+        <h2 className="text-3xl text-black mt-2">The short version</h2>
+        <p>
+          What the Sketch? is a game where you draw a prompt and an AI tries to guess it. We built
+          it to be fun and lightweight, so we collect as little as possible:{" "}
+          <strong>you don&apos;t need an account</strong>, and we never ask for your name or email
+          to play. This policy explains what little we do collect, why, and who else is involved
+          when you play.
+        </p>
+
+        <h2 className="text-3xl text-black mt-2">Information we collect</h2>
+        <p>When you play, two things are processed:</p>
+        <ul className="list-disc pl-6 flex flex-col gap-2">
+          <li>
+            <strong>Your drawings.</strong> The image you draw on the canvas is sent to our AI
+            provider so it can make a guess.
+          </li>
+          <li>
+            <strong>Your IP address.</strong> We read your IP address to enforce a daily usage limit
+            and prevent abuse of the AI service.
+          </li>
+        </ul>
+        <p>
+          We do <strong>not </strong>collect names, email addresses, or account credentials, and we
+          don&apos;t use advertising or tracking cookies.
+        </p>
+
+        <h2 className="text-3xl text-black mt-2">How we use it</h2>
+        <ul className="list-disc pl-6 flex flex-col gap-2">
+          <li>
+            <strong>Drawings </strong>are used only to generate the AI&apos;s guess during your
+            game.
+          </li>
+          <li>
+            <strong>Your IP address </strong>is used only to count requests against a limit of 50
+            per 24 hours, so one person can&apos;t run up the AI bill for everyone.
+          </li>
+        </ul>
+
+        <h2 className="text-3xl text-black mt-2">Services we share data with</h2>
+        <p>
+          To run the game we rely on a few third-party services. When you play, the relevant data
+          passes through them:
+        </p>
+        <ul className="list-disc pl-6 flex flex-col gap-2">
+          <li>
+            <strong>OpenRouter</strong> routes your drawing to the AI model.{" "}
+            <ExternalLink href="https://openrouter.ai/privacy">Privacy policy</ExternalLink>
+          </li>
+          <li>
+            <strong>Google (Gemini)</strong> is the AI model that analyzes your drawing and produces
+            a guess.{" "}
+            <ExternalLink href="https://policies.google.com/privacy">Privacy policy</ExternalLink>
+          </li>
+          <li>
+            <strong>Supabase</strong> stores the per-IP request counter used for rate limiting.{" "}
+            <ExternalLink href="https://supabase.com/privacy">Privacy policy</ExternalLink>
+          </li>
+          <li>
+            <strong>Vercel</strong> hosts the game and provides your IP address for rate limiting.{" "}
+            <ExternalLink href="https://vercel.com/legal/privacy-policy">
+              Privacy policy
+            </ExternalLink>
+          </li>
+        </ul>
+        <p>We don&apos;t sell your data, and we don&apos;t share it for advertising.</p>
+
+        <h2 className="text-3xl text-black mt-2">Data retention</h2>
+        <ul className="list-disc pl-6 flex flex-col gap-2">
+          <li>
+            <strong>Drawings </strong> are not stored on our servers. They&apos;re sent to the AI
+            provider to produce a guess and are not saved by us afterward. Their handling by
+            OpenRouter and Google is governed by the policies linked above.
+          </li>
+          <li>
+            <strong>Rate-limit records</strong> (your IP and a request count) are kept only as long
+            as needed to enforce the daily limit and are periodically cleared.
+          </li>
+        </ul>
+
+        <h2 className="text-3xl text-black mt-2">Cookies &amp; local storage</h2>
+        <p>
+          We don&apos;t use advertising or analytics tracking cookies. Your game progress lives in
+          your browser&apos;s memory during a session. Our hosting and infrastructure providers may
+          set essential cookies needed for the site to function.
+        </p>
+
+        <h2 className="text-3xl text-black mt-2">Children&apos;s privacy</h2>
+        <p>
+          What the Sketch? is not directed to children under 13, and we don&apos;t knowingly collect
+          personal information from them.
+        </p>
+
+        <h2 className="text-3xl text-black mt-2">Your rights</h2>
+        <p>
+          Depending on where you live, you may have rights to access or delete your personal data.
+          Because we hold so little — essentially a temporary counter tied to your IP address —
+          there is usually nothing personal to return or erase. If you have a request or question,
+          contact us and we&apos;ll help.
+        </p>
+
+        <h2 className="text-3xl text-black mt-2">Changes to this policy</h2>
+        <p>
+          If we update this policy, we&apos;ll change the &quot;Last updated&quot; date at the top
+          of this page. Continuing to play after a change means you accept the updated policy.
+        </p>
+
+        <h2 className="text-3xl text-black mt-2">Contact</h2>
+        <div>
+          <p>Questions about this policy? </p>
+          <p>
+            What the Sketch? is operated by Eric Zhang. You can reach me at{" "}
+            <a href={`mailto:${CONTACT_EMAIL}`} className="underline hover:text-black">
+              {CONTACT_EMAIL}
+            </a>
+            .
+          </p>
+        </div>
+      </div>
+      <Link
+        href="/"
+        className="underline hover:text-black text-center mt-6 hover:scale-105 transition"
+      >
+        ← Back to game
+      </Link>
+    </main>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -118,8 +118,8 @@ export default function PrivacyPage() {
         <h2 className="text-3xl text-black mt-2">Your rights</h2>
         <p>
           Depending on where you live, you may have rights to access or delete your personal data.
-          Because we hold so little — essentially a temporary counter tied to your IP address —
-          there is usually nothing personal to return or erase. If you have a request or question,
+          Because we hold so little, essentially a temporary counter tied to your IP address, there
+          is usually nothing personal to return or erase. If you have a request or question,
           contact us and we&apos;ll help.
         </p>
 

--- a/src/app/terms/__tests__/page.test.tsx
+++ b/src/app/terms/__tests__/page.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import TermsPage from "../page";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Terms of Service Page", () => {
+  it("renders the title and last updated date", () => {
+    render(<TermsPage />);
+
+    expect(screen.getByRole("heading", { level: 1, name: "Terms of Service" })).toBeInTheDocument();
+    expect(screen.getByText(/Last updated:/)).toBeInTheDocument();
+  });
+
+  it("renders the key tailored sections", () => {
+    render(<TermsPage />);
+
+    expect(screen.getByRole("heading", { name: "Acceptable use" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "AI guesses" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "No warranties, no liability" })).toBeInTheDocument();
+  });
+
+  it("links to the privacy policy", () => {
+    render(<TermsPage />);
+
+    const privacyLink = screen.getByRole("link", { name: "Privacy Policy" });
+    expect(privacyLink).toHaveAttribute("href", "/privacy");
+  });
+
+  it("provides a back-to-game link pointing at the home route", () => {
+    render(<TermsPage />);
+
+    const backLink = screen.getByRole("link", { name: /Back to game/ });
+    expect(backLink).toHaveAttribute("href", "/");
+  });
+});

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Terms of Service | What the Sketch?",
+  description: "The rules for playing What the Sketch?",
+};
+
+const CONTACT_EMAIL = "ericzhangdeveloper@gmail.com";
+
+export default function TermsPage() {
+  return (
+    <main className="container mx-auto max-w-3xl flex flex-col gap-4 pt-12 pb-24 px-4 text-lg sm:text-xl text-slate-800">
+      <h1 className="text-5xl sm:text-6xl text-center text-black">Terms of Service</h1>
+      <p className="text-base text-slate-600 text-center mb-4">Last updated: June 7, 2026</p>
+
+      <div className="flex flex-col gap-4 bg-white px-4 md:px-8 py-6 border-2 border-black shadow-[6px_8px_0px_0px_rgba(0,0,0,1)] rounded-3xl">
+        <h2 className="text-3xl text-black mt-2">The short version</h2>
+        <p>
+          What the Sketch? is a free browser game: you draw a prompt and an AI guesses it. By
+          playing, you agree to these terms. If you don&apos;t agree, please don&apos;t use the game.
+          You must be at least 13 to play.
+        </p>
+
+        <h2 className="text-3xl text-black mt-2">Acceptable use</h2>
+        <p>Don&apos;t use the game to:</p>
+        <ul className="list-disc pl-6 flex flex-col gap-2">
+          <li>submit illegal, hateful, harassing, sexually explicit, or abusive content;</li>
+          <li>break the law or infringe anyone&apos;s rights;</li>
+          <li>overload, attack, or reverse-engineer the game or its AI; or</li>
+          <li>bypass the rate limit, scrape, copy, or resell it.</li>
+        </ul>
+        <p>We may block access for misuse.</p>
+
+        <h2 className="text-3xl text-black mt-2">Your drawings</h2>
+        <p>
+          You&apos;re responsible for what you draw, and you keep ownership of it. By submitting a
+          drawing, you allow us to send it to our AI provider to generate a guess. See our{" "}
+          <Link href="/privacy" className="underline hover:text-black">
+            Privacy Policy
+          </Link>{" "}
+          for details.
+        </p>
+
+        <h2 className="text-3xl text-black mt-2">AI guesses</h2>
+        <p>
+          Guesses are generated automatically and are just part of the game. They may be wrong,
+          nonsensical, or unintentionally offensive, and are provided for entertainment only.
+          Don&apos;t rely on them, and they don&apos;t reflect our views.
+        </p>
+
+        <h2 className="text-3xl text-black mt-2">No warranties, no liability</h2>
+        <p>
+          What the Sketch? is a free hobby project, provided &quot;as is&quot; and &quot;as
+          available&quot; with no warranties. We may change or shut it down at any time, and to the
+          fullest extent allowed by law, we&apos;re not liable for any damages from using it. You
+          play at your own risk.
+        </p>
+
+        <h2 className="text-3xl text-black mt-2">Our content</h2>
+        <p>
+          The game&apos;s name, code, artwork, and design belong to Eric Zhang; please don&apos;t
+          copy or redistribute it. Your drawings stay yours.
+        </p>
+
+        <h2 className="text-3xl text-black mt-2">Third-party services</h2>
+        <p>
+          The game runs on OpenRouter, Google, Supabase, and Vercel, whose terms also apply.
+          We&apos;re not responsible for their services.
+        </p>
+
+        <h2 className="text-3xl text-black mt-2">Changes &amp; contact</h2>
+        <p>
+          We may update these terms; we&apos;ll change the date above, and continued play means you
+          accept the changes. Questions? What the Sketch? is operated by Eric Zhang. Reach me at{" "}
+          <a href={`mailto:${CONTACT_EMAIL}`} className="underline hover:text-black">
+            {CONTACT_EMAIL}
+          </a>
+          .
+        </p>
+      </div>
+      <Link
+        href="/"
+        className="underline hover:text-black text-center mt-6 hover:scale-105 transition"
+      >
+        ← Back to game
+      </Link>
+    </main>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,15 @@
+// Minimal themed footer with legal links.
+
+import Link from "next/link";
+
+export default function Footer() {
+  return (
+    <footer className="w-full flex flex-col sm:flex-row mt-auto items-center justify-center gap-2 sm:gap-4 pt-4 pb-8 text-lg text-slate-600">
+      <Link href="/privacy" className="hover:text-black hover:underline transition-colors">
+        Privacy Policy
+      </Link>
+      <span className="hidden sm:inline">·</span>
+      <span>© 2026 What the Sketch?</span>
+    </footer>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,6 +9,10 @@ export default function Footer() {
         Privacy Policy
       </Link>
       <span className="hidden sm:inline">·</span>
+      <Link href="/terms" className="hover:text-black hover:underline transition-colors">
+        Terms of Service
+      </Link>
+      <span className="hidden sm:inline">·</span>
       <span>© {new Date().getFullYear()} Eric Zhang · What the Sketch?</span>
     </footer>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,7 +9,7 @@ export default function Footer() {
         Privacy Policy
       </Link>
       <span className="hidden sm:inline">·</span>
-      <span>© 2026 What the Sketch?</span>
+      <span>© {new Date().getFullYear()} Eric Zhang · What the Sketch?</span>
     </footer>
   );
 }

--- a/src/components/Lobby.tsx
+++ b/src/components/Lobby.tsx
@@ -3,6 +3,7 @@ import { AI_PERSONALITIES, AIPersonality, PROMPT_CATEGORIES, PromptCategory } fr
 import Image from "next/image";
 import Button from "./Button";
 import DropDownList from "./DropDownList";
+import Footer from "./Footer";
 export default function Lobby() {
   const setPromptCategory = useGameStore((state) => state.setPromptCategory);
   const promptCategory = useGameStore((state) => state.promptCategory);
@@ -11,14 +12,14 @@ export default function Lobby() {
   const startGame = useGameStore((state) => state.startGame);
 
   return (
-    <main className="container mx-auto flex flex-col items-center gap-10 justify-center pt-20 px-4">
+    <main className="container mx-auto flex flex-col items-center gap-10 justify-center pt-20 px-4 min-h-screen">
       <Image
         aria-label="what-the-sketch-banner"
         src="/banner.webp"
         alt="What the Sketch? Banner"
         width={900}
         height={314}
-        className="w-full max-w-3xl h-auto"
+        className="w-full max-w-2xl h-auto"
         priority
       ></Image>
       <DropDownList
@@ -34,6 +35,7 @@ export default function Lobby() {
         onChange={(value: string) => setAiPersonality(value as AIPersonality)}
       ></DropDownList>
       <Button onClick={startGame}>Start Game!</Button>
+      <Footer />
     </main>
   );
 }

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import Footer from "../Footer";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Footer", () => {
+  it("renders a link to the privacy policy", () => {
+    render(<Footer />);
+
+    const privacyLink = screen.getByRole("link", { name: "Privacy Policy" });
+    expect(privacyLink).toHaveAttribute("href", "/privacy");
+  });
+});

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -14,4 +14,11 @@ describe("Footer", () => {
     const privacyLink = screen.getByRole("link", { name: "Privacy Policy" });
     expect(privacyLink).toHaveAttribute("href", "/privacy");
   });
+
+  it("renders a link to the terms of service", () => {
+    render(<Footer />);
+
+    const termsLink = screen.getByRole("link", { name: "Terms of Service" });
+    expect(termsLink).toHaveAttribute("href", "/terms");
+  });
 });


### PR DESCRIPTION
## Summary

Adds the legal pages needed to take What the Sketch? public: a `/privacy` and a `/terms` route, plus a footer to make them discoverable. Both are written in plain language and tailored to how the game actually handles data (user drawings sent to the AI, IP-based rate limiting), rather than generic boilerplate.

## Changes

- **`/privacy`** (`src/app/privacy/page.tsx`) - Privacy Policy covering what's collected (drawings, IP), how it's used, the third parties involved (OpenRouter, Google, Supabase, Vercel), retention, cookies, children's privacy, user rights, and contact.
- **`/terms`** (`src/app/terms/page.tsx`) - Terms of Service: acceptance/eligibility, acceptable use, drawing ownership + processing license, AI-output disclaimer, no-warranty/liability, IP ownership, third-party services, changes & contact.
- **Footer** (`src/components/Footer.tsx`) - links to Privacy and Terms plus a copyright line; added to the lobby (`src/components/Lobby.tsx`), which was restructured to a `min-h-dvh` flex column so the footer anchors to the bottom of the screen and stays responsive.
- **Tests** - render tests for both pages (titles, key sections, cross-links, back link) and the footer links.

## Notes

- Both pages are server components and prerender as static content; they reuse the existing neo-brutalist theme (Patrick Hand, graph-paper background, bordered white card).
- Contact email is `ericzhangdeveloper@gmail.com`; the operator/copyright is attributed to Eric Zhang.
- Out of scope (separate work): the `ip_rate_limits` RLS / rate-limit hardening, spending caps, and OG/social meta tags.

## Reflection

 So this is all the boring legal stuff, right, and damn, there's a lot of CYA.   Something that probably just needs to happen before I launch, so I'm glad that it's done now. 

## Issues 
- Closes #101 